### PR TITLE
Display Top 2 Citations Using Cosine Similarity with LLM Response

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -124,11 +124,11 @@ def display_top_n_citations(context: List[Document], llm_response: str, embeddin
     llm_response_embedding = embedding_paragraph(llm_response, embeddings)
 
     similarity_scores = []
-    for idx, context in enumerate(context):
-        context_content = context.page_content[:1000]
-        context_embedding = embedding_paragraph(context_content, embeddings)
-        similarity_score = calculate_semantic_similarity(llm_response_embedding, context_embedding)
-        similarity_scores.append([idx, similarity_score, context_content])
+    for idx, doc in enumerate(context):
+        doc_content = doc.page_content[:1000]
+        doc_embedding = embedding_paragraph(doc_content, embeddings)
+        similarity_score = calculate_semantic_similarity(llm_response_embedding, doc_embedding)
+        similarity_scores.append([idx, similarity_score, doc_content])
         sorted_similarity_scores = sorted(similarity_scores, key= lambda x: x[1], reverse=True)
     top_n_citations = sorted_similarity_scores[:n]
     return [citation[2] for citation in top_n_citations]

--- a/wise_friend_streamlit.py
+++ b/wise_friend_streamlit.py
@@ -60,8 +60,9 @@ if st.button("Add Entry"):
         response = (
             utils.generate(content, retrieved_docs, llm, prompt) if not dry_run else ""
         )
+        top_citations = utils.display_top_n_citations(retrieved_docs, response, embeddings, n=2) if not dry_run else ""
         st.write(f"Your wise friend says: {response}")
-        st.write(f"Reference: {utils.display_top_n_citations(retrieved_docs, response, embeddings, n=2)}")
+        st.write(f"Reference: {top_citations}")
     else:
         st.error("Please enter some content.")
 


### PR DESCRIPTION
**Description**
This PR introduces logic to display the top 2 citations based on cosine similarity between the embeddings of the LLM response and the embeddings of retrieved documents.

**Key Changes:**
1. Compute cosine similarity between LLM response embedding and retrieved document embeddings
2. Select and display the top 2 most relevant citations
<img width="1004" alt="Screenshot 2025-03-24 at 11 50 16 AM" src="https://github.com/user-attachments/assets/6c7597f8-6897-405e-b9ee-97a9b232ba76" />

**Future Improvements:**
1. **UI enhancement**: Improve front-end formatting to display citations in a more readable and user-friendly format.
2. **Embedding optimization**: Avoid redundant embedding calculations by retrieving existing embeddings using document IDs from the wise collection.