### PR TITLE
Custom prompt 

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,7 +19,7 @@ Keep the tone warm, empathetic, and true to the original context. If there are m
 
 If unsure about the answer, say so honestly while still offering validation or encouragement. The goal is to foster self-understanding and growth through a supportive and empowering response.
 
-Length Constraint: Keep the response under 3 paragraphs or 150 words.
+Length Constraint: Keep the response under 3 paragraphs or 300 words.
 Opening Diversity: Begin with varied expressions of empathy. Do not reuse the same sentence starter (e.g., “I can sense,” “It sounds like,” “I understand”, "It seems like") more than once within a 3-day window. Vary emotional verbs, tone, and sentence structure to maintain freshness and authenticity.
 
 User Journal: {journal_entry}

--- a/config.py
+++ b/config.py
@@ -10,7 +10,23 @@ WISE_COLLECTION_TABLE = "collection_table"
 
 # Prompt related variables
 PROMPT = "randomguy/rag_with_chat_history_and_citation"  # Original: "rlm/rag-prompt"
-SUPPORTIVE_MESSAGE_CONTENT = "You are a wise, supportive inner voice. Offer empathetic, gentle guidance using provided context to replace self-criticism with empowering insights or new perspectives."
+SUPPORTIVE_MESSAGE_CONTENT = "You are a wise, supportive inner voice. Offer empathetic guidance using insights from the user's uploaded wise collection to replace self-criticism with empowering perspectives."
+
+PROMPT_TEMPLATE = """
+After reading the user's journal entry, respond with compassion, support, and encouragement—similar to how a therapist might speak. Acknowledge the user's emotions, validate their experience, and, if appropriate, offer gentle guidance or insights based on the retrieved wise collection.
+
+Keep the tone warm, empathetic, and true to the original context. If there are multiple references, weave them in naturally without losing clarity.
+
+If unsure about the answer, say so honestly while still offering validation or encouragement. The goal is to foster self-understanding and growth through a supportive and empowering response.
+
+Length Constraint: Keep the response under 3 paragraphs or 150 words.
+Opening Diversity: Begin with varied expressions of empathy. Do not reuse the same sentence starter (e.g., “I can sense,” “It sounds like,” “I understand”, "It seems like") more than once within a 3-day window. Vary emotional verbs, tone, and sentence structure to maintain freshness and authenticity.
+
+User Journal: {journal_entry}
+Previous Responses (Past 3 Days): {response_starter_history}
+Retrieved Wise Collection: {context}
+Wise Response:
+"""
 
 PSQL_URL = "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"  # Uses psycopg3!
 

--- a/utils.py
+++ b/utils.py
@@ -3,10 +3,9 @@ import re
 from enum import Enum
 
 import numpy as np
-from langchain import hub
 from langchain_community.document_loaders.pdf import PyMuPDFLoader
 from langchain_core.documents import Document
-from langchain_core.messages import SystemMessage
+from langchain_core.messages import SystemMessage, HumanMessage
 from langchain_core.vectorstores import VectorStore
 from langchain_fireworks import ChatFireworks, FireworksEmbeddings
 from langchain_postgres.vectorstores import PGVector
@@ -30,9 +29,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-prompt = hub.pull(config.PROMPT)
-
-
 class Category(Enum):
     DOCUMENT = "document"
 
@@ -51,43 +47,53 @@ def concatenate(outputs: list):
 # Generate streaming response
 @traceable(reduce_fn=concatenate)
 async def generate_streaming(
-    query: str,
-    context: List[Document],
-    llm: ChatFireworks,
-    prompt,
+    query: str, context: List[Document], llm: ChatFireworks
 ) -> AsyncGenerator[Tuple[str, str], None]:
     docs_content = "\n\n".join(doc.page_content for doc in context)
-    base_messages = prompt.invoke(
-        {"question": query, "context": docs_content, "history": None}
-    ).to_messages()
-    # Prepend the supportive system message
-    supportive_message = SystemMessage(content=config.SUPPORTIVE_MESSAGE_CONTENT)
 
-    messages = [supportive_message] + base_messages
+    # Structure the prompt messages
+    messages = [
+        SystemMessage(content=config.SUPPORTIVE_MESSAGE_CONTENT),
+        HumanMessage(
+            content=config.PROMPT_TEMPLATE.format(
+                journal_entry=query,
+                response_starter_history=None,
+                context=docs_content,
+            )
+        ),
+    ]
+    # Get the run.id to use it in logging user feedback for LLM responses
+    # and for tracing.
     run = get_current_run_tree()
     run_id = run.id
-    first = True
 
+    first_chunk = True
     async for chunk in llm.astream(messages):
         content = chunk.content or ""
-        if first:
+        if first_chunk:
             yield content, run_id  # yield run_id with the first chunk
-            first = False
+            first_chunk = False
         else:
             yield content, None  # only content afterwards
 
 
 # Generate non-streaming response
 @traceable
-def generate(query: str, context: List[Document], llm: ChatFireworks, prompt):
+def generate(query: str, context: List[Document], llm: ChatFireworks):
     docs_content = "\n\n".join(doc.page_content for doc in context)
-    base_messages = prompt.invoke(
-        {"question": query, "context": docs_content, "history": None}
-    ).to_messages()
-    # Prepend the supportive system message
-    supportive_message = SystemMessage(content=config.SUPPORTIVE_MESSAGE_CONTENT)
 
-    messages = [supportive_message] + base_messages
+    # Structure the prompt messages
+    messages = [
+        SystemMessage(content=config.SUPPORTIVE_MESSAGE_CONTENT),
+        HumanMessage(
+            content=config.PROMPT_TEMPLATE.format(
+                journal_entry=query,
+                response_starter_history=None,
+                context=docs_content,
+            )
+        ),
+    ]
+
     run = get_current_run_tree()
     print(f"generate Run Id: {run.id}")
     response = llm.invoke(messages)

--- a/wise_friend_streamlit.py
+++ b/wise_friend_streamlit.py
@@ -86,11 +86,9 @@ def display_journal_entry(entry, date):
         st.markdown(f"**Journal Entry:**  \n\n*{entry}*")
 
 
-async def stream_response(query, retrieved_docs, llm, prompt, response_placeholder):
+async def stream_response(query, retrieved_docs, llm, response_placeholder):
     response_text = ""
-    async for token, run_id in utils.generate_streaming(
-        query, retrieved_docs, llm, prompt
-    ):
+    async for token, run_id in utils.generate_streaming(query, retrieved_docs, llm):
         response_text += token
         response_placeholder.write(response_text)
         if run_id:
@@ -112,7 +110,6 @@ def display_wise_response():
                     st.session_state.journal_entry,
                     retrieved_docs,
                     llm,
-                    utils.prompt,
                     response_placeholder,
                 )
             )


### PR DESCRIPTION
**Key Changes:**
Use a custom prompt to
- Vary response starters
- Limit response length to under 300 words
- Remove unnecessary inline citation references

**TODO:**
Retrieve Wise LLM responses from the past 3 days for a given user to help avoid repeated sentence starters. Since we're not currently storing LLM-generated responses in our DB, two possible solutions:
1. Store the Wise responses directly in our DB
2. Store the LangSmith run ID with each journal entry and later query LangSmith traces for past responses

(@eugene7505: Should I wait until the Supabase DB migration is complete before proceeding with this to-do item?)